### PR TITLE
sarpik/hotfix/students-with-more-than-two-words-in-their-name

### DIFF
--- a/common/src/model/Class.ts
+++ b/common/src/model/Class.ts
@@ -152,7 +152,8 @@ function parseClassNum(fullClassOrig: string): TClassNum {
 			`\
 \`classNum\` is NOT an integer!
 
-provided = \`${classNumDangerous}\`,
+provided = \`${fullClassOrig}\`
+parsed & invalid = \`${classNumDangerous}\`,
 typeof = \`${typeof classNumDangerous}\``
 		);
 	}

--- a/common/src/model/Student.ts
+++ b/common/src/model/Student.ts
@@ -249,7 +249,9 @@ export class StudentFromList {
 				`\
 \`classNum\` is NOT an integer!
 
-provided = \`${classNumDangerous}\`,
+
+provided = \`${this.originalHref}\`
+parsed & invalid = \`${classNumDangerous}\`,
 typeof = \`${typeof classNumDangerous}\``
 			);
 		}

--- a/common/src/model/Student.ts
+++ b/common/src/model/Student.ts
@@ -340,11 +340,16 @@ provided = \`${classNumDangerous}\``
 		 * * NOT have the `G` between them,
 		 * * have the `G` or `g` as either upper or lower case
 		 *
+		 * The `text` might contain more than two words:
+		 * someone might have two first names or two last names,
+		 * and only now I have noticed it:D
+		 *
 		 * and other bs, because as far as we understand,
 		 * it's typed in manually, without selection or assertion.
 		 *
 		 */
-		const fullClassOrig: string = this.text.split(" ")[2];
+		const splitText: string[] = this.text.split(" ");
+		const fullClassOrig: string = splitText[splitText.length - 1];
 		/**       "Melnikovas Kipras IIIGe"  */
 		/* ["Melnikovas", "Kipras", "IIIGe"] */
 		/**                         "IIIGe" */


### PR DESCRIPTION
Instead of taking the third word, we take the last one,
because a student can have more than 2 words (+ classname)
describing them:D

Fixes https://github.com/sarpik/turbo-schedule/issues/42