### PR TITLE
sarpik/default-api-routes

### DIFF
--- a/server/src/route/apiRouter.ts
+++ b/server/src/route/apiRouter.ts
@@ -5,4 +5,7 @@ const router: Router = Router();
 
 router.use("/v1", apiRouterV1);
 
+/** default to the latest API (MUST be the last route) */
+router.use("/", apiRouterV1);
+
 export { router as apiRouter };

--- a/server/src/route/v1/apiV1.ts
+++ b/server/src/route/v1/apiV1.ts
@@ -21,4 +21,7 @@ router.use("/email", emailRouter);
 router.use("/docs", openAPIDocsHTMLHandler);
 router.use("/docs.json", openAPIDocsJSONHandler);
 
+/** default to the docs (MUST be the last route) */
+router.use("/", openAPIDocsHTMLHandler);
+
 export { router as apiRouterV1 };


### PR DESCRIPTION
Provide API route defaults for `/api/` ( -> `/api/v1`) and `/api/v1/` (`/api/v1/docs`)