### PR TITLE
sarpik/typescript-with-pipeline-operator

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,7 @@
 		"concurrently": "^5.0.0",
 		"cross-env": "^6.0.3",
 		"node-sass": "^4.13.0",
-		"typescript": "^3.8.2"
+		"typescript": "https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/72713/artifacts?artifactName=tgz&fileId=5FDC6B0458B0184B85D790D1EB8AA47C0924EADA6FBC0575C4425A46F70973E002&fileName=/typescript-4.0.0-insiders.20200503.tgz"
 	},
 	"eslintConfig": {
 		"extends": "eslint-config-sarpik"

--- a/common/package.json
+++ b/common/package.json
@@ -21,7 +21,7 @@
 	},
 	"devDependencies": {
 		"ts-node-dev": "^1.0.0-pre.44",
-		"typescript": "^3.8.2"
+		"typescript": "https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/72713/artifacts?artifactName=tgz&fileId=5FDC6B0458B0184B85D790D1EB8AA47C0924EADA6FBC0575C4425A46F70973E002&fileName=/typescript-4.0.0-insiders.20200503.tgz"
 	},
 	"repository": {
 		"type": "git",

--- a/database/package.json
+++ b/database/package.json
@@ -16,7 +16,7 @@
 		"uuid": "^7.0.2"
 	},
 	"devDependencies": {
-		"typescript": "^3.8.2"
+		"typescript": "https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/72713/artifacts?artifactName=tgz&fileId=5FDC6B0458B0184B85D790D1EB8AA47C0924EADA6FBC0575C4425A46F70973E002&fileName=/typescript-4.0.0-insiders.20200503.tgz"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
 		"postinstall-postinstall": "^2.0.0",
 		"prettier": "^1.16.4",
 		"rimraf": "^3.0.0",
-		"typescript": "^3.8.2"
+		"typescript": "https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/72713/artifacts?artifactName=tgz&fileId=5FDC6B0458B0184B85D790D1EB8AA47C0924EADA6FBC0575C4425A46F70973E002&fileName=/typescript-4.0.0-insiders.20200503.tgz"
 	}
 }

--- a/scraper/package.json
+++ b/scraper/package.json
@@ -33,7 +33,7 @@
 		"@types/node": "^12.12.7",
 		"nodemon": "^1.19.3",
 		"ts-node-dev": "^1.0.0-pre.44",
-		"typescript": "^3.8.2"
+		"typescript": "https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/72713/artifacts?artifactName=tgz&fileId=5FDC6B0458B0184B85D790D1EB8AA47C0924EADA6FBC0575C4425A46F70973E002&fileName=/typescript-4.0.0-insiders.20200503.tgz"
 	},
 	"keywords": [
 		"turbo",

--- a/server/package.json
+++ b/server/package.json
@@ -61,7 +61,7 @@
 		"supertest": "^4.0.2",
 		"ts-jest": "^24.1.0",
 		"ts-node-dev": "^1.0.0-pre.44",
-		"typescript": "^3.8.2"
+		"typescript": "https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/72713/artifacts?artifactName=tgz&fileId=5FDC6B0458B0184B85D790D1EB8AA47C0924EADA6FBC0575C4425A46F70973E002&fileName=/typescript-4.0.0-insiders.20200503.tgz"
 	},
 	"resolutions": {
 		"express-oas-generator/swagger-ui-express": "^4.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15146,10 +15146,9 @@ typescript@^3.7.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
   integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
-typescript@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
-  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
+"typescript@https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/72713/artifacts?artifactName=tgz&fileId=5FDC6B0458B0184B85D790D1EB8AA47C0924EADA6FBC0575C4425A46F70973E002&fileName=/typescript-4.0.0-insiders.20200503.tgz":
+  version "4.0.0-insiders.20200503"
+  resolved "https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/72713/artifacts?artifactName=tgz&fileId=5FDC6B0458B0184B85D790D1EB8AA47C0924EADA6FBC0575C4425A46F70973E002&fileName=/typescript-4.0.0-insiders.20200503.tgz#bbee74f6f63a822f955da081d3ea7539bcb2985a"
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
Oh boy, I tried to extend typescript, webpack, babel, ts-loader, ttypescript
myself, but it looks like you cannot change stuff unless you modify the
private stuff, which is a shame.

Good news - someone implemented this at the private scope (the compiler itself),
meaning we can use it xoxo

Fixes https://github.com/sarpik/turbo-schedule/issues/77